### PR TITLE
Lever now allows Account Names with capital letters

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ window.loadLeverJobs = function (options) {
   var pageUrl = window.location.href;
   var leverParameter = '';
   var trackingPrefix = '?lever-';
-  options.accountName = options.accountName.toLowerCase();
+  options.accountName = options.accountName;
   // Define the container where we will put the content (or put in the body)
   var jobsContainer = document.getElementById("lever-jobs-container") || document.body;
 


### PR DESCRIPTION
The plugin currently doesn't work for us because it converts the Account Name to lowercase. Here's an example of our endpoint working with uppercase: https://api.lever.co/v0/postings/Ionic?limit=3&mode=json